### PR TITLE
FIX Check travis-ci.com instead of travis-ci.org

### DIFF
--- a/src/Check/CIPassingCheck.php
+++ b/src/Check/CIPassingCheck.php
@@ -39,7 +39,7 @@ class CIPassingCheck extends Check
     {
         try {
             $result = $this->getRequestClient()
-                ->get('https://api.travis-ci.org/repositories/' . $slug . '.json', $this->getOptions())
+                ->get('https://api.travis-ci.com/repositories/' . $slug . '.json', $this->getOptions())
                 ->getBody();
         } catch (Exception $ex) {
             if ($logger = $this->getSuite()->getLogger()) {


### PR DESCRIPTION
fixes #19
travis-ci.org hasn't allowed new builds to run since June 15th 2021 so it doesn't make sense to check it anymore.

This change will require a valid travis-ci.com token in the `TRAVIS_CI_TOKEN` environment variable.